### PR TITLE
using myhtml_tag_id_t in breaking vector instead of unsigned long

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -51,7 +51,7 @@ Examples:
 static const string afmt_s = "\033[";
 static const string afmt_e = "m";
 static const vector<char> collapsible = {' ', '\t', '\n', '\r'};
-static const vector<unsigned long> breaking = {
+static const vector<myhtml_tag_id_t> breaking = {
   MyHTML_TAG_BR,
   MyHTML_TAG_P
 };


### PR DESCRIPTION
Fails to build on 32-bit Intel (and ARMv6, ARMv7):

```
../main.cpp: In lambda function:
../main.cpp:204:43: error: no matching function for call to ‘vec_has(const std::vector<long unsigned int>&, myhtml_tag_id_t&)’
     if(vec_has(breaking, node_iter->tag_id)){ // <br/>
                                           ^
../main.cpp:101:35: note: candidate: ‘template<class T> bool vec_has(const std::vector<T>&, T)’
 template <typename T> inline bool vec_has(const vector<T> &vec, T val){
                                   ^~~~~~~
../main.cpp:101:35: note:   template argument deduction/substitution failed:
../main.cpp:204:43: note:   deduced conflicting types for parameter ‘T’ (‘long unsigned int’ and ‘unsigned int’)
     if(vec_has(breaking, node_iter->tag_id)){ // <br/>
                                           ^
ninja: build stopped: subcommand failed.
```