### PR TITLE
Use heading markup for the subsections of the Use section

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ The executable will be built to `build/hq`.
 
 #### Use
 
-Application help text: 
+##### Application help text
+
 ```
 hq (html query) - commandline HTML processor © Robin Broda, 2018
 Usage: build/hq [options] <selector> <mode> [mode argument]
@@ -57,7 +58,7 @@ Examples:
   curl -sSL https://example.com | build/hq a attr href
 ```
 
-Example usage:
+#### Example usage
 
 `curl -s https://coderobe.net | hq a data`
 ```


### PR DESCRIPTION
This allows one to directly link to the subsections using the automatically generated link tags (eg. <https://github.com/coderobe/hq#example-usage>)

Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>